### PR TITLE
Release 1.0 bugfix for Gutenburg Editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ node_modules/
 # ignore env config
 .env
 *.env
+
+# ignore mac fs rubbish
+.DS_Store

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -39,6 +39,7 @@ services:
     volumes:
       - wordpress:/var/www/html 
       - ./nginx/app.conf:/etc/nginx/nginx.conf
+      - ../src/plugins:/var/www/html/wp-content/plugins
 
   db:
     image: mysql:5.7.22

--- a/docker/nginx/app.conf
+++ b/docker/nginx/app.conf
@@ -50,6 +50,12 @@ http {
                 root /var/www/html;
         }
 
+        # Set expires max on static file types
+        location ~* ^.+\.(css|js|jpg|jpeg|gif|png|ico|gz|svg|svgz|ttf|otf|woff|eot|mp4|ogg|ogv|webm)$ {
+                expires max;
+                root /var/www/html;
+        }
+
         location / {
                 try_files $uri $uri/ /index.php$is_args$args;
         }
@@ -74,9 +80,5 @@ http {
         location = /robots.txt { 
                 log_not_found off; access_log off; allow all; 
         }
-        location ~* \.(css|gif|ico|jpeg|jpg|js|png)$ {
-                expires max;
-                log_not_found off;
-        }
-}
+    }
 }

--- a/src/plugins/amazon-product-import/admin/class-amazon-product-import-admin.php
+++ b/src/plugins/amazon-product-import/admin/class-amazon-product-import-admin.php
@@ -268,12 +268,6 @@ class Amazon_Product_Import_Admin {
 		foreach ($updates as $update) {
 
 			// Update all the relevant post meta
-			
-			// Update the title
-			wp_update_post( [
-				'ID' => $update['post'],
-				'post_title' => $update['title'],
-			] );
 
 			// Update the author
 			if (isset($update['author']) && !empty($update['author'])) {
@@ -313,6 +307,27 @@ class Amazon_Product_Import_Admin {
 
 					$posts[0] = $new_author;
 				}
+
+				// Get the post content so that we can replace values for gutenburg editor
+				$content = get_post_field('post_content', $update['post']);
+
+				// Searching for 
+				// <!-- wp:tribe/event-organizer /-->
+				// Replacing with
+				// <!-- wp:tribe/event-organizer {"organizer":711} /-->
+
+				$updated_post_content = str_replace( 
+					'<!-- wp:tribe/event-organizer /-->', 
+					'<!-- wp:tribe/event-organizer {"organizer": ' . $posts[0] . '} /-->',
+					$content
+				);
+
+				// Update the title and content
+				wp_update_post( [
+					'ID' => $update['post'],
+					'post_title' => $update['title'],
+					'post_content' => $updated_post_content,
+				] );
 
 				if (!empty($posts[0])) {
 					// we can just update this posts's author with the new organizer

--- a/src/plugins/index.php
+++ b/src/plugins/index.php
@@ -1,0 +1,2 @@
+<?php
+// Silence is golden.


### PR DESCRIPTION
This PR addresses an issue when using the Gutenburg WP editor for event posts in The Events Calendar not displaying the organizer field. This is because the "value" for this is being provided in `post_content` rather than using `post_meta` db table. 

This PR also updates the development environment to work nicely with WordPress permalinks.