### PR TITLE
Fix Feature Images From Amazon

### DIFF
--- a/featured-image.php
+++ b/featured-image.php
@@ -16,13 +16,9 @@
  * @see tribe_get_event() For the format of the event object.
  */
 
-if ( ! $event->thumbnail->exists ) {
-	return;
-}
-
 $image_url = get_post_meta($event->ID, 'amazon_product_image_url');
 
-if (empty($image_url)) : ?>
+if (empty($image_url) && $event->thumbnail->exists) : ?>
 
 <div class="tribe-events-calendar-list__event-featured-image-wrapper tribe-common-g-col">
 	<a
@@ -47,7 +43,7 @@ if (empty($image_url)) : ?>
 	</a>
 </div>
 
-<?php else : ?>
+<?php elseif (!empty($image_url)) : ?>
 
 <div class="tribe-events-calendar-list__event-featured-image-wrapper tribe-common-g-col">
     <img


### PR DESCRIPTION
Fix logic for pulling an image from amazon if we have one and falling back to uploaded image otherwise for the events calendar single event feature image template